### PR TITLE
fix decoding error in IRC protocol handler

### DIFF
--- a/circuits/protocols/irc/utils.py
+++ b/circuits/protocols/irc/utils.py
@@ -76,7 +76,7 @@ def parsemsg(s, encoding="utf-8"):
     :returns tuple: parsed message in the form of (prefix, command, args)
     """
 
-    s = s.decode(encoding)
+    s = s.decode(encoding, 'replace')
 
     prefix = ""
     trailing = []


### PR DESCRIPTION
If the connected opposite party send bytes which can't be decoded in the
set encoding (UTF-8 by default) the server/client crashed with a error
event. We are replacing invalid characters now. Users of the lib can
e.g. send a NOTIFY command to the client to inform the client about its
broken encoding. This can be easily added by registering another handler
for the "Line" event.