### PR TITLE
fix module assignment in circuits.six

### DIFF
--- a/circuits/six.py
+++ b/circuits/six.py
@@ -171,7 +171,7 @@ for attr in _moved_attributes:
     setattr(_MovedItems, attr.name, attr)
 del attr
 
-moves = sys.modules["six.moves"] = _MovedItems("moves")
+moves = sys.modules["circuits.six.moves"] = _MovedItems("moves")
 
 
 def add_move(move):


### PR DESCRIPTION
overwriting sys.modules['six.moves'] causes projects to fail which are
using the original six module. e.g.:

>>> import circuits.six
>>> import matplotlib.pyplot
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/matplotlib/pyplot.py", line 34, in <module>
    from matplotlib.figure import Figure, figaspect
  File "/usr/lib/python2.7/site-packages/matplotlib/figure.py", line 40, in <module>
    from matplotlib.axes import Axes, SubplotBase, subplot_class_factory
  File "/usr/lib/python2.7/site-packages/matplotlib/axes/__init__.py", line 4, in <module>
    from ._subplots import *
  File "/usr/lib/python2.7/site-packages/matplotlib/axes/_subplots.py", line 10, in <module>
    from matplotlib.axes._axes import Axes
  File "/usr/lib/python2.7/site-packages/matplotlib/axes/_axes.py", line 5, in <module>
    from six.moves import reduce, xrange, zip, zip_longest
ImportError: cannot import name zip_longest