### PR TITLE
Improove traceback format in Debugger

### DIFF
--- a/circuits/core/debugger.py
+++ b/circuits/core/debugger.py
@@ -11,7 +11,7 @@ each event to sys.stderr or to a Logger Component instance.
 
 import os
 import sys
-from traceback import format_exc
+from traceback import format_exc, format_exception_only
 from signal import SIGINT, SIGTERM
 
 
@@ -82,7 +82,9 @@ class Debugger(BaseComponent):
         )
 
         s.append(msg)
+        s.append('Traceback (most recent call last):\n')
         s.extend(traceback)
+        s.extend(format_exception_only(error_type, value))
         s.append("\n")
 
         if self.logger is not None:


### PR DESCRIPTION
Improove the output by adding the exception message after the traceback:

```
ERROR <handler[*.handler] (Class._on_event)> (<event[channel] arg>) (<type 'exceptions.KeyError'>): KeyError(1,)
Traceback (most recent call last):
  File "/home/arch/git/circuits/circuits/core/manager.py", line 618, in _dispatcher
    value = handler(*eargs, **ekwargs)
  File "foo.py", line 1, in __main__
    dict[1]
KeyError: 1
```

Too bad, that the argument 'traceback' already is a list created by traceback,format_tb() instead of the real traceback from sys.exc_info()[2].