### PR TITLE
web: add "expose_circuits" options in web server

### DIFF
--- a/circuits/web/constants.py
+++ b/circuits/web/constants.py
@@ -36,11 +36,15 @@ DEFAULT_ERROR_MESSAGE = """\
   <h1>%(name)s</h1>
   %(description)s
   <pre id="traceback">%(traceback)s</pre>
-  <div id="powered_by">
-   <span>Powered by <a href="%(url)s">%(version)s</a></span>
-  </div>
+  %(powered_by)s
  </body>
 </html>
+"""
+
+POWERED_BY = """
+<div id="powered_by">
+    <span>Powered by <a href="%(url)s">%(version)s</a></span>
+</div>
 """
 
 HTTP_STATUS_CODES = {

--- a/circuits/web/errors.py
+++ b/circuits/web/errors.py
@@ -7,7 +7,11 @@
 This module implements a set of standard HTTP Errors.
 """
 
-from cgi import escape
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape  # Deprecated since version 3.2
+
 
 try:
     from urllib.parse import urljoin as _urljoin

--- a/circuits/web/errors.py
+++ b/circuits/web/errors.py
@@ -21,7 +21,7 @@ except ImportError:
 from circuits import Event
 
 from ..six import string_types
-from .constants import SERVER_URL, SERVER_VERSION
+from .constants import SERVER_URL, SERVER_VERSION, POWERED_BY
 from .constants import DEFAULT_ERROR_MESSAGE, HTTP_STATUS_CODES
 
 
@@ -66,13 +66,17 @@ class httperror(Event):
 
         self.response.headers["Content-Type"] = self.contenttype
 
+        powered_by = POWERED_BY % ({
+            "url": SERVER_URL,
+            "version": SERVER_VERSION
+        }) if getattr(request.server, 'expose_circuits', False) else ''
+
         self.data = {
             "code": self.code,
             "name": HTTP_STATUS_CODES.get(self.code, "???"),
             "description": self.description,
             "traceback": escape(self.traceback),
-            "url": SERVER_URL,
-            "version": SERVER_VERSION
+            "powered_by": powered_by
         }
 
     def sanitize(self):

--- a/circuits/web/servers.py
+++ b/circuits/web/servers.py
@@ -56,10 +56,12 @@ class BaseServer(BaseComponent):
     channel = "web"
 
     def __init__(self, bind, encoding="utf-8", secure=False, certfile=None,
-                 channel=channel):
+                 channel=channel, expose_circuits=True):
         "x.__init__(...) initializes x; see x.__class__.__doc__ for signature"
 
         super(BaseServer, self).__init__(channel=channel)
+
+        self.__expose_circuits = expose_circuits
 
         if isinstance(bind, (int, list, tuple,)):
             SocketType = TCPServer
@@ -86,6 +88,10 @@ class BaseServer(BaseComponent):
     def port(self):
         if hasattr(self, "server"):
             return self.server.port
+
+    @property
+    def expose_circuits(self):
+        return self.__expose_circuits
 
     @property
     def secure(self):

--- a/circuits/web/wrappers.py
+++ b/circuits/web/wrappers.py
@@ -302,7 +302,8 @@ class Response(object):
         self.headers["Date"] = formatdate()
 
         if self.request.server is not None:
-            self.headers.add_header("Server", self.request.server.http.version)
+            if getattr(self.request.server, 'expose_circuits', False):
+                self.headers.add_header("Server", request.server.http.version)
         else:
             self.headers.add_header("X-Powered-By", SERVER_VERSION)
 


### PR DESCRIPTION
In general, security by obscurity is one of the weakest forms of security. But in some cases, every little bit of extra security is desirable.

A few simple techniques can help to hide Circuits details, possibly slowing down an attacker who is attempting to discover weaknesses in your system. By setting expose_circuits to False in your Server constructor, you reduce the amount of information available to them.