### PR TITLE
Prevent SSL server socket without certificate

### DIFF
--- a/circuits/net/sockets.py
+++ b/circuits/net/sockets.py
@@ -373,7 +373,10 @@ class Server(BaseComponent):
         self.secure = secure
 
         if self.secure:
-            self.certfile = kwargs.get("certfile", None)
+            try:
+                self.certfile = kwargs["certfile"]
+            except KeyError:
+                raise RuntimeError("certfile must be specified for server-side operations")
             self.keyfile = kwargs.get("keyfile", None)
             self.cert_reqs = kwargs.get("cert_reqs", CERT_NONE)
             self.ssl_version = kwargs.get("ssl_version", PROTOCOL_SSLv23)


### PR DESCRIPTION
It is too late to catch this if the application already runs:

<exception[server] (<type 'exceptions.ValueError'>, ValueError('certfile must be specified for server-side operations',), tb, handler=<bound method ?._on_read of <TCPServer/server 13150:MainThread (queued=1) [R]>>, fevent=<_read[server] (<socket._socketobject object at 0x7faff88dbbb0> )>)>
ERROR <handler[*._read] (TCPServer._on_read)> (<_read[server]
(<socket._socketobject object at 0x7faff88dbbb0> )>) (<type 'exceptions.ValueError'>): ValueError('certfile must be specified for server-side operations',)
Traceback (most recent call last):
  File "~/git/circuits/circuits/core/manager.py", line 627, in
_dispatcher
    value = handler(*eargs, **ekwargs)
  File "~/git/circuits/circuits/net/sockets.py", line 584, in
_on_read
    self._accept()
  File "~/git/circuits/circuits/net/sockets.py", line 534, in
_accept
    do_handshake_on_connect=False
  File "/usr/lib/python2.7/ssl.py", line 891, in wrap_socket
    ciphers=ciphers)
  File "/usr/lib/python2.7/ssl.py", line 498, in __init__
    raise ValueError("certfile must be specified for server-side "
ValueError: certfile must be specified for server-side operations