### PR TITLE
Fixed failing coroutine test (test was written incorrectly)

### DIFF
--- a/tests/core/test_coroutine.py
+++ b/tests/core/test_coroutine.py
@@ -16,9 +16,13 @@ class test(Event):
 class coroutine1(Event):
     """coroutine Event"""
 
+    complete = True
+
 
 class coroutine2(Event):
     """coroutine Event"""
+
+    complete = True
 
 
 class App(Component):
@@ -37,7 +41,8 @@ class App(Component):
 
     def coroutine2(self):
         print("coroutine2")
-        yield self.wait(self.fire(test()))
+        self.fire(test())
+        yield self.wait("test")
         print("returned")
         self.returned = True
 
@@ -57,9 +62,10 @@ def app(request, manager, watcher):
 
 def test_coroutine(manager, watcher, app):
     manager.fire(coroutine1())
-    assert watcher.wait("coroutine1")
+    assert watcher.wait("coroutine1_complete")
     assert app.returned, "coroutine1"
+
     app.returned = False
     manager.fire(coroutine2())
-    assert watcher.wait("coroutine2")
+    assert watcher.wait("coroutine2_complete")
     assert app.returned, "coroutine2"


### PR DESCRIPTION
Test passes:

```
#!bash
$ py.test -x -s -v tests/core/test_coroutine.py 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.9 -- py-1.4.27 -- pytest-2.7.0 -- /home/prologic/.virtualenvs/circuits/bin/python
rootdir: /home/prologic/work/circuits, inifile: 
plugins: cov
collected 1 items 

tests/core/test_coroutine.py::test_coroutine <registered[*] (<Debugger/* 14267:Manager (queued=0) [S]>, <Manager/ 14267:Manager (queued=3) [R]> )>
<registered[*] (<Watcher/* 14267:Manager (queued=0) [S]>, <Manager/ 14267:Manager (queued=2) [R]> )>
<registered[*] (<App/* 14267:Manager (queued=0) [S]>, <Manager/ 14267:Manager (queued=1) [R]> )>
<coroutine1[*] ( )>
coroutine1
<test[*] ( )>
<test_done[*] ('Hello World!' )>
returned
<coroutine1_complete[*] (<coroutine1[*] ( )>, None )>
<coroutine2[*] ( )>
coroutine2
<test[*] ( )>
<test_done[*] ('Hello World!' )>
returned
<coroutine2_complete[*] (<coroutine2[*] ( )>, None )>
PASSED<prepare_unregister[*] (<App/* 14267:Manager (queued=0) [S]> )>
<prepare_unregister[*] (<Watcher/* 14267:Manager (queued=0) [S]> )>
<prepare_unregister_complete[<App/* 14267:Manager (queued=0) [S]>] (<prepare_unregister[*] (<App/* 14267:Manager (queued=0) [S]> )>, None )>
<prepare_unregister_complete[<Watcher/* 14267:Manager (queued=0) [S]>] (<prepare_unregister[*] (<Watcher/* 14267:Manager (queued=0) [S]> )>, None )>
<unregistered[*] (<App/* 14267:Manager (queued=0) [S]>, <Manager/ 14267:Manager (queued=2) [R]> )>
<unregistered[*] (<Watcher/* 14267:Manager (queued=0) [S]>, <Manager/ 14267:Manager (queued=1) [R]> )>


=============================================== 1 passed in 1.03 seconds ===============================================
```