### PR TITLE
Adapt reprhandler(): include priority, join with ,

### DIFF
--- a/circuits/core/handlers.py
+++ b/circuits/core/handlers.py
@@ -94,7 +94,7 @@ class Unknown(object):
 
 
 def reprhandler(handler):
-    format = "<handler[%s.%s] (%s.%s)>"
+    format = "<handler[%s][%s]%s (%s.%s)>"
 
     channel = getattr(handler, "channel", "*")
     if channel is None:
@@ -104,7 +104,7 @@ def reprhandler(handler):
     if isinstance(channel, Manager):
         channel = "<instance of " + channel.__class__.__name__ + ">"
 
-    names = ".".join(handler.names)
+    names = ",".join(handler.names)
 
     instance = getattr(
         handler, "im_self", getattr(
@@ -114,7 +114,9 @@ def reprhandler(handler):
 
     method = handler.__name__
 
-    return format % (channel, names, instance, method)
+    priority = "[%0.2f]" % (handler.priority,) if handler.priority else ""
+
+    return format % (channel, names, priority, instance, method)
 
 
 class HandlerMetaClass(type):

--- a/docs/source/man/debugger.rst
+++ b/docs/source/man/debugger.rst
@@ -88,6 +88,6 @@ Logged Exceptions::
     <Value () result=False; errors=False; for <foo[*] ( )>
     >>> <foo[*] ( )>
     <exception[*] (<type 'exceptions.TypeError'>, TypeError('foo() takes exactly 3 arguments (1 given)',), ['  File "/home/prologic/work/circuits/circuits/core/manager.py", line 561, in _dispatcher\n    value = handler(*eargs, **ekwargs)\n'] handler=<bound method App.foo of <App/* 27098:App (queued=1) [R]>>, fevent=<foo[*] ( )>)>
-    ERROR <handler[*.foo] (App.foo)> (<foo[*] ( )>) {<type 'exceptions.TypeError'>}: foo() takes exactly 3 arguments (1 given)
+    ERROR <handler[*][foo] (App.foo)> (<foo[*] ( )>) {<type 'exceptions.TypeError'>}: foo() takes exactly 3 arguments (1 given)
       File "/home/prologic/work/circuits/circuits/core/manager.py", line 561, in _dispatcher
           value = handler(*eargs, **ekwargs)

--- a/docs/source/man/misc/tools.rst
+++ b/docs/source/man/misc/tools.rst
@@ -37,11 +37,11 @@ Example:
 
      Event Handlers: 3
       unregister; 1
-       <handler[*.unregister] (App._on_unregister)>
+       <handler[*][unregister] (App._on_unregister)>
       foo; 1
-       <handler[*.foo] (App.foo)>
+       <handler[*][foo] (App.foo)>
       prepare_unregister_complete; 1
-       <handler[<instance of App>.prepare_unregister_complete] (App._on_prepare_unregister_complete)>
+       <handler[<instance of App>][prepare_unregister_complete] (App._on_prepare_unregister_complete)>
    
 
 Displaying a Visual Representation of your Application

--- a/tests/core/test_debugger.py
+++ b/tests/core/test_debugger.py
@@ -300,4 +300,4 @@ def test_Logger_error():
     while app:
         app.flush()
 
-    assert logger.error_msg.startswith("ERROR <handler[*.test] (App.test)> (")
+    assert logger.error_msg.startswith("ERROR <handler[*][test] (App.test)> (")

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -118,9 +118,9 @@ def test_inspect():
     assert "Components: 0" in s
     assert "Event Handlers: 2" in s
     assert "foo; 1" in s
-    assert "<handler[*.foo] (A.foo)>" in s
+    assert "<handler[*][foo] (A.foo)>" in s
     assert "prepare_unregister_complete; 1" in s
-    assert "<handler[<instance of A>.prepare_unregister_complete] (A._on_prepare_unregister_complete)>" in s
+    assert "<handler[<instance of A>][prepare_unregister_complete] (A._on_prepare_unregister_complete)>" in s
 
 
 def test_findroot():
@@ -144,7 +144,7 @@ def test_findroot():
 def test_reprhandler():
     a = A()
     s = reprhandler(a.foo)
-    assert s == "<handler[*.foo] (A.foo)>"
+    assert s == "<handler[*][foo] (A.foo)>"
 
     f = lambda: None
     pytest.raises(AttributeError, reprhandler, f)


### PR DESCRIPTION
before: ```<handler[channel.event1.event2] (Foo._on_event1_2)>```
After: ``` <handler[channel][event1,event2][1.3] (Foo._on_event1_2)>```