### PR TITLE
Web: catch OSError crash

### DIFF
--- a/circuits/web/wrappers.py
+++ b/circuits/web/wrappers.py
@@ -175,11 +175,19 @@ class Request(object):
         self.cookie = SimpleCookie()
 
         if sock is not None:
-            name = sock.getpeername()
+            try:
+                name = sock.getpeername()
+            except OSError:
+                name = None
+
             if name is not None:
                 self.remote = Host(*name)
             else:
-                name = sock.getsockname()
+                try:
+                    name = sock.getsockname()
+                except OSError:
+                    name = 'unknown'
+
                 self.remote = Host(name, "", name)
 
         cookie = self.headers.get("Cookie")


### PR DESCRIPTION
2015-06-09 17:16:09 CRITICAL ERROR <handler[*][read] (HTTP._on_read)> (<read[web] (<ssl.SSLSocket [closed] fd=-1, family=AddressFamily.AF_INET, type=2049, proto=0>, b'POST / HTTP/1.1\r\nAccept-Encoding: identity\r\nConnection: close\r\nContent-Length: 4\r\nUser-Agent: Python-urllib/3.4\r\nHost: example.com\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nlog=test' )>) (<class 'OSError'>): OSError(9, 'Bad file descriptor')  File "circuits/circuits/core/manager.py", line 668, in _dispatcher
    value = event_handler(*eargs, **ekwargs)
  File "circuits/circuits/web/http.py", line 270, in _on_read
    headers=parser.get_headers(), server=self._server
  File "circuits/circuits/web/wrappers.py", line 186, in __init__
    name = sock.getsockname()