### PR TITLE
Remove templatebuiltins.js from documentation

### DIFF
--- a/docs/source/_themes/om/layout.html
+++ b/docs/source/_themes/om/layout.html
@@ -18,39 +18,6 @@
 
 {% block extrahead %}
 {{ super() }}
-<script type="text/javascript" src="{{ pathto('templatebuiltins.js', 1) }}"></script>
-<script type="text/javascript">
-(function($) {
-    if (!django_template_builtins) {
-       // templatebuiltins.js missing, do nothing.
-       return;
-    }
-    $(document).ready(function() {
-        // Hyperlink Django template tags and filters
-        var base = "{{ pathto('ref/templates/builtins') }}";
-        if (base == "#") {
-            // Special case for builtins.html itself
-            base = "";
-        }
-        // Tags are keywords, class '.k'
-        $("div.highlight\\-html\\+django span.k").each(function(i, elem) {
-             var tagname = $(elem).text();
-             if ($.inArray(tagname, django_template_builtins.ttags) != -1) {
-                 var fragment = tagname.replace(/_/, '-');
-                 $(elem).html("<a href='" + base + "#" + fragment + "'>" + tagname + "</a>");
-             }
-        });
-        // Filters are functions, class '.nf'
-        $("div.highlight\\-html\\+django span.nf").each(function(i, elem) {
-             var filtername = $(elem).text();
-             if ($.inArray(filtername, django_template_builtins.tfilters) != -1) {
-                 var fragment = filtername.replace(/_/, '-');
-                 $(elem).html("<a href='" + base + "#" + fragment + "'>" + filtername + "</a>");
-             }
-        });
-    });
-})(jQuery);
-</script>
 {% endblock %}
 
 {% block document %}


### PR DESCRIPTION
templatebuiltins.js contains names of Django builtin tags and filters
not used in circuits documentation.