### PR TITLE
Don't install tests and fabfile packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,18 @@ setup(
     license="MIT",
     keywords="event framework distributed concurrent component asynchronous",
     platforms="POSIX",
-    packages=find_packages("."),
+    packages=find_packages(
+        exclude=[
+            "*.tests",
+            "*.tests.*",
+            "tests.*",
+            "tests",
+            "*.fabfile",
+            "*.fabfile.*",
+            "fabfile.*",
+            "fabfile",
+        ]
+    ),
     scripts=glob("bin/*"),
     install_requires=[],
     entry_points={


### PR DESCRIPTION
This way we can prevent polluting namespace during install. Having tests
in source dist is useful for downstream developers.

See #79.