### PR TITLE
Added OS X to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 sudo: false
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
+matrix:
+  include:
+    - os: linux
+      python: "2.7"
+    - os: osx
+      python: "2.7"
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update           ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pypy     ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python   ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3  ; fi
 install:
   - pip install pytest
   - pip install coveralls


### PR DESCRIPTION
This enables OS X testing on Travis CI and gives us a CI environment we can
ensure OS X specific features are working as well as circuits as a whole
functions correctly on OS X.

Closes #153