### PR TITLE
Add __pycache__ & py[co] exclusions to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,6 @@ prune docs
 prune fabfile
 prune examples
 prune setup.cfg
+
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Ensures binary, compiled files and cache directories are excluded from source distribution generation

Resolves #155 