### PR TITLE
Allow to run multiple io.process.Process objects simultaneously

### DIFF
--- a/tests/io/test_process.py
+++ b/tests/io/test_process.py
@@ -14,7 +14,7 @@ def test(manager, watcher):
     p.start()
     assert watcher.wait("started", p.channel)
 
-    assert watcher.wait("stopped", p.channel)
+    assert watcher.wait("terminated", p.channel)
 
     s = p.stdout.getvalue()
     assert s == b"Hello World!\n"
@@ -39,3 +39,29 @@ def test2(manager, watcher, tmpdir):
 
     with foo.open("r") as f:
         assert f.read() == "Hello World!"
+
+def test_two_procs(manager, watcher):
+    p1 = Process(["echo", "1"]).register(manager)
+    p2 = Process("echo 2 ; sleep 1", shell = True).register(manager)
+    
+    p1.start()
+    p2.start()
+    
+    assert watcher.wait("terminated", p1.channel)
+    assert p1._terminated
+    assert not p2._terminated
+    assert not p2._stdout_closed
+    assert not p2._stderr_closed
+    
+    watcher.clear()     # Get rid of first terminated()
+    
+    s1 = p1.stdout.getvalue()
+    assert s1 == b"1\n"
+    
+    assert watcher.wait("terminated", p2.channel)
+    assert p2._terminated
+    assert p2._stdout_closed
+    assert p2._stderr_closed
+    
+    s2 = p2.stdout.getvalue()
+    assert s2 == b"2\n"


### PR DESCRIPTION
Currently, Process incorrectly handles stdout/stderr channels which rely on
global state:
  - static methods used to handle read/close events are instantiated on
    module import. Thus, they are being mocked by addHandler() which sets
    .channel to them. Starting a new process causes resetting that field
    on the global method objects, thus all processes will receive output
    from the last started process. To mitigate this, static methods are
    replaced with closure-like lambdas.
  - Process incorrectly raises stopped() event to close stdout/stderr. This
    event, however, is used to signal Manager's death. Thus, when process is
    completed, all sockets/pipes in the entire program are closed. This is why
    stopped() event has to be replaced with process-specific terminated() event
    and we need explicitly send close() to all process pipes.