### PR TITLE
This enables chromium to connect to circuits websockets again

### DIFF
--- a/circuits/web/websockets/dispatcher.py
+++ b/circuits/web/websockets/dispatcher.py
@@ -57,7 +57,8 @@ class WebSocketsDispatcher(BaseComponent):
         self._protocol_version = 13
         headers = request.headers
         sec_key = headers.get("Sec-WebSocket-Key", "").encode("utf-8")
-
+        prot = headers.get("Sec-WebSocket-Protocol", "NONE")
+        
         connection_tokens = [s.strip() for s in
                              headers.get("Connection", "").lower().split(",")]
 
@@ -88,6 +89,8 @@ class WebSocketsDispatcher(BaseComponent):
             response.headers["Upgrade"] = "WebSocket"
             response.headers["Connection"] = "Upgrade"
             response.headers["Sec-WebSocket-Accept"] = accept.decode()
+            response.headers["Sec-WebSocket-Protocol"] = prot  # We hear you
+            
             codec = WebSocketCodec(request.sock, channel=self._wschannel)
             self._codecs[request.sock] = codec
             codec.register(self)


### PR DESCRIPTION
Not sure if it is a good idea to just echo the requested protocols, but if you look at the specs, they _are_ a bit _mad_: http://www.rfc-editor.org/rfc/rfc6455.txt (Pp. 6 ff.) - the IETF also instantiated a subprotocol registry (clearly: wtf!?)

Fixes #168 
