### PR TITLE
Fix crash from deleting undefined variables

### DIFF
--- a/circuits/__init__.py
+++ b/circuits/__init__.py
@@ -31,10 +31,11 @@ except ImportError:
     from pkgutil import extend_path
     __path__ = extend_path(__path__, __name__)
     import os
+    from .six import exec_
+    fd = None
     for _path in __path__:
         _path = os.path.join(_path, '__init__.py')
         if _path != __file__ and os.path.exists(_path):
-            from .six import exec_
             with open(_path) as fd:
                 exec_(fd, globals())
     del os, extend_path, _path, fd, exec_


### PR DESCRIPTION
This fixes an unhandled NameError introduced in 3.2 that occurs when running a Circuits app packaged with Py2EXE using the single zip file option (did not test other options).

Fixes #171 