### PR TITLE
Fixes a complete event bug (#123)

### DIFF
--- a/circuits/core/manager.py
+++ b/circuits/core/manager.py
@@ -413,8 +413,9 @@ class Manager(object):
 
     def _fire(self, event, channel, priority=0):
         # check if event is fired while handling an event
-        if thread.get_ident() == (self._executing_thread or
-                                  self._flushing_thread) and not isinstance(event, signal):
+        th = (self._executing_thread or self._flushing_thread)
+        if thread.get_ident() == (th.ident if th else None) and \
+                not isinstance(event, signal):
             if self._currently_handling is not None and \
                     getattr(self._currently_handling, "cause", None):
                 # if the currently handled event wants to track the


### PR DESCRIPTION
I think I found the bug. The code I changed were comparing the thread's ident with a thread object itself (or None), which always end up with False so the code inside the if block was never executed.

This commit appears to have fixed the tests users reported.

Fixes #123 

