### PR TITLE
Fix DoS socket/memory leak for not connected clients

### DIFF
--- a/circuits/net/sockets.py
+++ b/circuits/net/sockets.py
@@ -155,6 +155,9 @@ class Client(BaseComponent):
 
         try:
             self._sock.shutdown(2)
+        except SocketError:
+            pass
+        try:
             self._sock.close()
         except SocketError:
             pass
@@ -497,6 +500,9 @@ class Server(BaseComponent):
 
         try:
             sock.shutdown(2)
+        except SocketError:
+            pass
+        try:
             sock.close()
         except SocketError:
             pass


### PR DESCRIPTION
If a client disconnects sock.close() is currently never called because one cannot shutdown a not connected client:
```
Traceback (most recent call last):
  File "circuits/net/sockets.py", line 460, in _close
    sock.shutdown(2)
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 107] Transport endpoint is not connected
```
This leads to still opened file descriptors/sockets in the procees:
python  20195 spaceone   10u  sock      0,6      0t0 11410688 can't identify protocol

If the server component runs for a longer time somehwen the open file descriptor limits is reached and your server is not able to react to any connection anymore:
Errno 105: No buffer space available