### PR TITLE
Switched to universal wheels.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ build-dir  = docs/build
 
 [upload_sphinx]
 upload-dir  = docs/build/html
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Circuits does not ship C-extensions, nor does it need 2to3 to run to
work on python 3. This means one wheel is enough, currently the PyPi
wheels are py2 only!

This changes the generated wheels to be named like:
```
circuits-3.3-py2.py3-none-any.whl
```
instead of
```
circuits-3.3-py2-none-any.whl
```
ie py2.py3 instead of just py2