### PR TITLE
[WIP] Issue198

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ python:
 
 matrix:
   allow_failures:
-    # Till https://travis-ci.org/circuits/circuits/jobs/192188096 is solved.
-    - python: pypy
     # Till https://travis-ci.org/circuits/circuits/jobs/192669838 is solved.
     - os: osx
   include:


### PR DESCRIPTION
If this works out on PyPY the patch needs cleanups. I am also imagining
the following: Always use a deque and add a flag to the manager if
priority events should be supported. If not we don't have to use the
heap queue at all which might result in performance improvements.