### PR TITLE
Add support to set additional socket options

### DIFF
--- a/tests/net/test_socket_options.py
+++ b/tests/net/test_socket_options.py
@@ -1,0 +1,13 @@
+import pytest
+
+from circuits.net.sockets import TCPServer
+
+try:
+    from socket import SOL_SOCKET, SO_REUSEPORT
+except ImportError:
+    pytestmark = pytest.mark.skip(reason='Missing SO_REUSEPORT')
+
+
+def test_socket_options_server():
+    s = TCPServer(('0.0.0.0', 8090), socket_options=[(SOL_SOCKET, SO_REUSEPORT, 1)])
+    assert s._sock.getsockopt(SOL_SOCKET, SO_REUSEPORT) == 1


### PR DESCRIPTION
```
from circuits.net.sockets import TCPServer
from socket import SOL_SOCKET, SO_REUSEPORT
s = TCPServer(('0.0.0.0', 8090), socket_options=[(SOL_SOCKET, SO_REUSEPORT, 1)])
assert s._sock.getsockopt(SOL_SOCKET, SO_REUSEPORT) == 1
```
Fixes #102 
