### PR TITLE
Documentation: Cannot import name `WebSockets`

### DIFF
--- a/docs/source/web/howtos.rst
+++ b/docs/source/web/howtos.rst
@@ -128,7 +128,7 @@ trivial example:
     
     from circuits.net.events import write
     from circuits import Component, Debugger
-    from circuits.web.dispatchers import WebSockets
+    from circuits.web.dispatchers import WebSocketsDispatcher
     from circuits.web import Controller, Logger, Server, Static
     
     
@@ -152,7 +152,7 @@ trivial example:
     Echo().register(app)
     Root().register(app)
     Logger().register(app)
-    WebSockets("/websocket").register(app)
+    WebSocketsDispatcher("/websocket").register(app)
     app.run()
 
 See the `circuits.web examples <https://github.com/circuits/circuits/tree/master/examples/web>`_.


### PR DESCRIPTION
I think the example code for Websockets might be slightly out of date.

I attempted to run the code, and python returned an error:
```
Traceback (most recent call last):
  File "file.py", line 5, in <module>
    from circuits.web.dispatchers import WebSockets
ImportError: cannot import name 'WebSockets'
```
I believe it's because it should be importing `WebSocketsDispatcher` instead. The examples in the examples directory would seem to agree with this.

Please describe what this pull request implements, improves or fixes.
Please be clear and concise but terse. We can read the code :)
