### PR TITLE
make __str__ compatible with py2

### DIFF
--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -1,7 +1,7 @@
 """
 This defines the Value object used by components and events.
 """
-from ..six import string_types
+from ..six import string_types, PY2
 from .events import Event
 
 
@@ -72,7 +72,8 @@ class Value(object):
 
     def __str__(self):
         "x.__str__() <==> str(x)"
-
+        if PY2:
+            return self.value.encode('utf-8')
         return str(self.value)
 
     def inform(self, force=False):

--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -1,7 +1,7 @@
 """
 This defines the Value object used by components and events.
 """
-from ..six import string_types, PY2
+from ..six import PY2, string_types
 from .events import Event
 
 


### PR DESCRIPTION
See a similar implementation in six:
https://github.com/circuits/circuits/blob/master/circuits/six.py#L840

Do we want to use the decorator and add `__unicode__`?

Fixes #229
