### PR TITLE
make __str__ compatible with py2 (six-decorator)

### DIFF
--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -4,6 +4,7 @@ This defines the Value object used by components and events.
 from ..six import python_2_unicode_compatible, string_types
 from .events import Event
 
+
 @python_2_unicode_compatible
 class Value(object):
 

--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -1,10 +1,10 @@
 """
 This defines the Value object used by components and events.
 """
-from ..six import string_types
+from ..six import python_2_unicode_compatible, string_types
 from .events import Event
 
-
+@python_2_unicode_compatible
 class Value(object):
 
     """Create a new future Value Object


### PR DESCRIPTION
This the one with decorator.
Also see: #232 and #229

A cleaner approve to fix __str__ in Value for Python2. This is the way as six suggests it.

Fixes #229 
