### PR TITLE
Fixed API call to networkx

### DIFF
--- a/circuits/tools/__init__.py
+++ b/circuits/tools/__init__.py
@@ -110,7 +110,7 @@ def graph(x, name=None):
         plt.axis("off")
 
         plt.savefig("{0:s}.png".format(name or x.name))
-        networkx.write_dot(g, "{0:s}.dot".format(name or x.name))
+        networkx.drawing.nx_agraph.write_dot(g, "{0:s}.dot".format(name or x.name))
 
         plt.clf()
 


### PR DESCRIPTION
NetworkX API has moved the write_dot command to a submodle:
networkx.write_dot -> networkx.drawing.nx_agraph.write_dot
