### PR TITLE
Added PY2 to imports in values.py

### DIFF
--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -1,7 +1,7 @@
 """
 This defines the Value object used by components and events.
 """
-from ..six import python_2_unicode_compatible, string_types
+from ..six import python_2_unicode_compatible, string_types, PY2
 from .events import Event
 
 


### PR DESCRIPTION
There was a missing "PY2" import from six.py in values.py. 
Fixed.
