### PR TITLE
Issue #246: pytest Metafunc.addcall is deprecated; replace with Metaf…

### DIFF
--- a/tests/net/test_pipe.py
+++ b/tests/net/test_pipe.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.skipif(pytest.PLATFORM == 'win32', reason='Unsupported 
 
 
 def pytest_generate_tests(metafunc):
-    metafunc.addcall(funcargs={"Poller": Select})
+    metafunc.parametrize("Poller", [Select])
 
 
 def test_pipe(Poller):

--- a/tests/net/test_tcp.py
+++ b/tests/net/test_tcp.py
@@ -78,23 +78,24 @@ def wait_host(server):
     assert pytest.wait_for(server, ("host", "port"), checker)
 
 
-def _pytest_generate_tests(metafunc, ipv6):
-    metafunc.addcall(funcargs={"Poller": Select, "ipv6": ipv6})
-
-    if hasattr(select, "poll"):
-        metafunc.addcall(funcargs={"Poller": Poll, "ipv6": ipv6})
-
-    if hasattr(select, "epoll"):
-        metafunc.addcall(funcargs={"Poller": EPoll, "ipv6": ipv6})
-
-    if hasattr(select, "kqueue"):
-        metafunc.addcall(funcargs={"Poller": KQueue, "ipv6": ipv6})
-
-
 def pytest_generate_tests(metafunc):
-    _pytest_generate_tests(metafunc, ipv6=False)
+    ipv6 = [False]
     if has_ipv6:
-        _pytest_generate_tests(metafunc, ipv6=True)
+        ipv6.append(True)
+
+    for ipv6 in ipv6:
+        poller = [(Select, ipv6)]
+
+        if hasattr(select, "poll"):
+            poller.append((Poll, ipv6))
+
+        if hasattr(select, "epoll"):
+            poller.append((EPoll, ipv6))
+
+        if hasattr(select, "kqueue"):
+            poller.append((KQueue, ipv6))
+
+    metafunc.parametrize('Poller,ipv6', poller)
 
 
 def test_tcp_basic(Poller, ipv6):

--- a/tests/net/test_udp.py
+++ b/tests/net/test_udp.py
@@ -19,23 +19,24 @@ def wait_host(server):
     assert pytest.wait_for(server, ("host", "port"), checker)
 
 
-def _pytest_generate_tests(metafunc, ipv6):
-    metafunc.addcall(funcargs={"Poller": Select, "ipv6": ipv6})
-
-    if hasattr(select, "poll"):
-        metafunc.addcall(funcargs={"Poller": Poll, "ipv6": ipv6})
-
-    if hasattr(select, "epoll"):
-        metafunc.addcall(funcargs={"Poller": EPoll, "ipv6": ipv6})
-
-    if hasattr(select, "kqueue"):
-        metafunc.addcall(funcargs={"Poller": KQueue, "ipv6": ipv6})
-
-
 def pytest_generate_tests(metafunc):
-    _pytest_generate_tests(metafunc, ipv6=False)
+    ipv6 = [False]
     if socket.has_ipv6:
-        _pytest_generate_tests(metafunc, ipv6=True)
+        ipv6.append(True)
+
+    for ipv6 in ipv6:
+        poller = [(Select, ipv6)]
+
+        if hasattr(select, "poll"):
+            poller.append((Poll, ipv6))
+
+        if hasattr(select, "epoll"):
+            poller.append((EPoll, ipv6))
+
+        if hasattr(select, "kqueue"):
+            poller.append((KQueue, ipv6))
+
+    metafunc.parametrize('Poller,ipv6', poller)
 
 
 def test_basic(Poller, ipv6):

--- a/tests/net/test_unix.py
+++ b/tests/net/test_unix.py
@@ -27,16 +27,17 @@ def tmpfile(request):
 
 
 def pytest_generate_tests(metafunc):
-    metafunc.addcall(funcargs={"Poller": Select})
+    poller = [Select]
 
     if hasattr(select, "poll"):
-        metafunc.addcall(funcargs={"Poller": Poll})
+        poller.append(Poll)
 
     if hasattr(select, "epoll"):
-        metafunc.addcall(funcargs={"Poller": EPoll})
+        poller.append(EPoll)
 
     if hasattr(select, "kqueue"):
-        metafunc.addcall(funcargs={"Poller": KQueue})
+        poller.append(KQueue)
+    metafunc.parametrize('Poller', poller)
 
 
 def test_unix(tmpfile, Poller):


### PR DESCRIPTION
…unc.parametrize

Fixes #246
