### PR TITLE
Fix CRLF injection in IRC protocol

### DIFF
--- a/circuits/protocols/irc/message.py
+++ b/circuits/protocols/irc/message.py
@@ -13,12 +13,13 @@ class Error(Exception):
 class Message(object):
 
     def __init__(self, command, *args, **kwargs):
-        for arg in args[:-1]:
-            if u(" ") in arg:
-                raise Error("Space can only appear in the very last arg")
+        if any(u(' ') in arg for arg in args[:-1]):
+            raise Error("Space can only appear in the very last arg")
+        if any(u('\n') in arg for arg in args):
+            raise Error("No newline allowed")
 
         self.command = command
-        self.args = list(filter(lambda x: x is not None, list(args)))
+        self.args = [x for x in args if x is not None]
         self.prefix = text_type(kwargs["prefix"]) if "prefix" in kwargs else None
 
         self.encoding = kwargs.get("encoding", "utf-8")
@@ -41,11 +42,12 @@ class Message(object):
 
     def __unicode__(self):
         args = self.args[:]
-        for arg in args[:-1]:
-            if arg is not None and u(" ") in arg:
-                raise Error("Space can only appear in the very last arg")
+        if any(u(' ') in arg for arg in args[:-1]):
+            raise Error("Space can only appear in the very last arg")
+        if any(u('\n') in arg for arg in args):
+            raise Error("No newline allowed")
 
-        if len(args) > 0 and u(" ") in args[-1] and args[-1][0] != u(":"):
+        if args and u(" ") in args[-1] and not args[-1].startswith(u(":")):
             args[-1] = u(":{0:s}").format(args[-1])
 
         return u("{prefix:s}{command:s} {args:s}\r\n").format(


### PR DESCRIPTION
```
>>> print bytes(irc.Message("PRIVMSG", 'spaceone', 'test test\r\nPRIVMSG ChanServ SET PASSWORD foo'))
PRIVMSG spaceone :test test
PRIVMSG ChanServ SET PASSWORD foo
```