### PR TITLE
Fix pytest deprecation of pytest_namespace()

### DIFF
--- a/examples/testing/pytest/conftest.py
+++ b/examples/testing/pytest/conftest.py
@@ -104,9 +104,9 @@ def watcher(request, manager):
     return watcher
 
 
-def pytest_namespace():
-    return dict((
-        ("WaitEvent", WaitEvent),
-        ("PLATFORM", sys.platform),
-        ("PYVER", sys.version_info[:3]),
-    ))
+for key, value in dict((
+    ("WaitEvent", WaitEvent),
+    ("PLATFORM", sys.platform),
+    ("PYVER", sys.version_info[:3]),
+)).items():
+    setattr(pytest, key, value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,12 +142,12 @@ def watcher(request, manager):
     return watcher
 
 
-def pytest_namespace():
-    return dict((
-        ("WaitEvent", WaitEvent),
-        ("wait_for", wait_for),
-        ("call_event", call_event),
-        ("PLATFORM", sys.platform),
-        ("PYVER", sys.version_info[:3]),
-        ("call_event_from_name", call_event_from_name),
-    ))
+for key, value in dict((
+    ("WaitEvent", WaitEvent),
+    ("wait_for", wait_for),
+    ("call_event", call_event),
+    ("PLATFORM", sys.platform),
+    ("PYVER", sys.version_info[:3]),
+    ("call_event_from_name", call_event_from_name),
+)).items():
+    setattr(pytest, key, value)


### PR DESCRIPTION
This PR is not ready yet. It seems the test cases fail because of a newer pytest version and a API change inside of pytest. I need this PR to trigger the travis builds. 