### PR TITLE
Fix python2 str(circuits.core.values.Value())

### DIFF
--- a/circuits/core/values.py
+++ b/circuits/core/values.py
@@ -74,7 +74,7 @@ class Value(object):
     def __str__(self):
         "x.__str__() <==> str(x)"
         if PY2:
-            return self.value.encode('utf-8')
+            return unicode(self.value).encode('utf-8')
         return str(self.value)
 
     def inform(self, force=False):


### PR DESCRIPTION
I am not sure why Value has a `__str__` method at all. But it's broken on
python2. It assumes value is always a unicode-string, while coroutines
can return anything, even lists. This causes various crashes.

```
>>> str(circuits.core.values.Value())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/fbest/git/circuits/circuits/six.py", line 854, in <lambda>
    klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
  File "/home/fbest/git/circuits/circuits/core/values.py", line 78, in __str__
    return self.value.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```