### PR TITLE
Fix error handling after handshake

### DIFF
--- a/circuits/net/sockets.py
+++ b/circuits/net/sockets.py
@@ -636,11 +636,8 @@ class Server(BaseComponent):
             try:
                 self.fire(connect(sock, *sock.getpeername()))
             except SocketError as exc:
-                if exc.args[0] in (ENOTCONN,):
-                    # the client already disconnected
-                    self._close(sock)
-                    return
-                raise
+                # errno 107 (ENOTCONN): the client already disconnected
+                self._on_handshake_error(sock, exc)
 
     def _on_handshake_error(self, sock, err):
         self.fire(error(sock, err))


### PR DESCRIPTION
fixes a race condition because sock.getpeername() might raise socket.error(errno=107, 'Transport endpoint is not connected')