### PR TITLE
Added a bufsize argument to the init of BaseServer

### DIFF
--- a/circuits/web/servers.py
+++ b/circuits/web/servers.py
@@ -8,6 +8,7 @@ from circuits import io
 from circuits.core import BaseComponent, Timer, handler
 from circuits.net.events import close, read, write
 from circuits.net.sockets import TCPServer, UNIXServer
+from circuits.net.sockets import BUFSIZE
 
 from .dispatchers import Dispatcher
 from .events import terminate
@@ -49,7 +50,7 @@ class BaseServer(BaseComponent):
     channel = "web"
 
     def __init__(self, bind, encoding="utf-8", secure=False, certfile=None,
-                 channel=channel, display_banner=True):
+                 channel=channel, display_banner=True, bufsize=BUFSIZE):
         "x.__init__(...) initializes x; see x.__class__.__doc__ for signature"
 
         super(BaseServer, self).__init__(channel=channel)
@@ -65,7 +66,8 @@ class BaseServer(BaseComponent):
             bind,
             secure=secure,
             certfile=certfile,
-            channel=channel
+            channel=channel,
+            bufsize=bufsize
         ).register(self)
 
         self.http = HTTP(

--- a/tests/net/test_server.py
+++ b/tests/net/test_server.py
@@ -1,0 +1,29 @@
+from circuits.web.servers import BaseServer
+from circuits.net.sockets import BUFSIZE
+
+
+class MockClass(BaseServer):
+    pass
+
+
+def test_dynamic_bufsize_in_baseserver():
+    bufsize = 10000
+    try:
+        # Assert when we set BUFSIZE ourselves
+        mock = MockClass(bind="0.0.0.0:1234", bufsize=bufsize)
+        # that it will be set to our given value
+        assert bufsize == mock.server._bufsize
+    finally:
+        mock.server.unregister()
+        mock.stop()
+
+
+def test_constant_bufsize_in_baseserver():
+    try:
+        # Assert when we dont set BUFSIZE ourself
+        mock = MockClass(bind="0.0.0.0:1235")
+        # that it will be set to the constant default value
+        assert mock.server._bufsize == BUFSIZE
+    finally:
+        mock.server.unregister()
+        mock.stop()


### PR DESCRIPTION
The use case for this is using a class that inherits from BaseServer such as Server and I would like to expose BUFSIZE as a configurable value.
Currently in circuits.net.sockets BUFSIZE is a constant of 4096 and this value is used unless set otherwise in the init of something like TCPServer.

You can import CONSTANTS, so using the already existing BUFSIZE CONSTANT as the default value if a user doesn't set bufsize themselves

What this allows is for classes that inherit from Server and BaseServer to specify their own BUFSIZE
