### PR TITLE
Fix Python3.7 compatibility + Add current Python versions to CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
+  - 3.9-dev
   - pypy
 
 matrix:

--- a/circuits/net/sockets.py
+++ b/circuits/net/sockets.py
@@ -296,7 +296,7 @@ class TCPClient(Client):
                 self.fire(unreachable(host, port, e))
                 self.fire(error(e))
                 self._close()
-                raise StopIteration()
+                return
 
         stop_time = time() + self.connect_timeout
         while time() < stop_time:
@@ -309,7 +309,7 @@ class TCPClient(Client):
 
         if not self._connected:
             self.fire(unreachable(host, port))
-            raise StopIteration()
+            return
 
         def on_done(sock):
             self._poller.addReader(self, sock)

--- a/circuits/web/parsers/querystring.py
+++ b/circuits/web/parsers/querystring.py
@@ -137,5 +137,3 @@ class QueryStringParser(object):
 
         if len(buf) > 0:
             yield QueryStringToken.KEY, buf
-        else:
-            raise StopIteration()


### PR DESCRIPTION
In Python 3.7 generators should not raise StopIteration anymore and instead return.
We should also add the current python versions to CI.