### PR TITLE
socket accept windows error handling

### DIFF
--- a/circuits/net/sockets.py
+++ b/circuits/net/sockets.py
@@ -476,9 +476,13 @@ class Server(BaseComponent):
                     self._poller.addReader(self, self._sock)
                     self.fire(ready(self, (self.host, self.port)))
                 else:
-                    self._poller = Poller().register(self)
-                    self._poller.addReader(self, self._sock)
-                    self.fire(ready(self, (self.host, self.port)))
+                    try:
+                        self._poller = Poller().register(self)
+                    except EnvironmentError as err:
+                        self.fire(error(err))
+                    else:
+                        self._poller.addReader(self, self._sock)
+                        self.fire(ready(self, (self.host, self.port)))
 
     @handler("stopped", channel="*")
     def _on_stopped(self, component):


### PR DESCRIPTION
* raise exception in main thread. (must)
* handle exceptions during poller initialization. (not sure about side effects and hiding of errors)

Fixes #197
