### PR TITLE
fix[circuits.web.main]: fix Python 3 compatibility of md5 hash

### DIFF
--- a/circuits/web/main.py
+++ b/circuits/web/main.py
@@ -106,7 +106,7 @@ class Authentication(Component):
     channel = "web"
 
     realm = "Secure Area"
-    users = {"admin": md5("admin").hexdigest()}
+    users = {"admin": md5(b"admin").hexdigest()}
 
     def __init__(self, channel=channel, realm=None, passwd=None):
         super(Authentication, self).__init__(self, channel=channel)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/git/circuits/circuits/web/main.py", line 104, in <module>
    class Authentication(Component):
  File "/home/git/circuits/circuits/web/main.py", line 109, in Authentication
    users = {"admin": md5("admin").hexdigest()}
TypeError: Unicode-objects must be encoded before hashing
```