### PR TITLE
Tox docs environment is broken

### DIFF
--- a/docs/circuits-docs.xml
+++ b/docs/circuits-docs.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><testsuite errors="0" failures="0" name="" skips="0" tests="2" time="2.389"><testcase classname="check_docs" name="test_linkcheck" time="1.17705798149"/><testcase classname="check_docs" name="test_build_docs" time="1.1587471962"/></testsuite>

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ passenv=TEST_STOMP_*
 
 [testenv:docs]
 basepython=python
+skip_install=True
 changedir=docs
 deps=
     sphinx
     pytest
     releases
-commands=py.test --junitxml=circuits-docs-{envname}.xml check_docs.py
+commands=py.test --junitxml=circuits-docs.xml check_docs.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ envlist=docs,py37,py38,py39,py310,py311,pypy
 skip_missing_interpreters=True
 
 [pytest]
-addopts=-r fsxX --durations=10 --ignore=tmp --timeout=30 --tb=native -lvv
+addopts=-r fsxX --durations=10 --ignore=tmp --tb=native -lvv
 
 [testenv]
-commands=py.test {posargs}
+commands=py.test --timeout=30 {posargs}
 extras= stomp
 deps=
     pytest


### PR DESCRIPTION
This addresses some chores around the docs/ directory:

- do not use the `--timeout` option in the docs environment
- remove 11 year old junit.xml file 
- do not use environment name (which is always `docs`) in the junit report name

