### PR TITLE
fix urlparse deprecations in jsonrpc tests

### DIFF
--- a/tests/web/jsonrpclib.py
+++ b/tests/web/jsonrpclib.py
@@ -32,7 +32,7 @@
 import base64
 import json
 from http.client import HTTPConnection, HTTPSConnection
-from urllib.parse import splithost, splittype, splituser, unquote
+from urllib.parse import urlparse, unquote
 
 
 __version__ = '0.0.1'
@@ -233,7 +233,9 @@ class Transport:
         if isinstance(host, tuple):
             host, x509 = host
 
-        auth, host = splituser(host)
+        parsed_url = urlparse(host)
+        auth = f"{parsed_url.username}:{parsed_url.password}"
+        host = parsed_url.hostname
 
         if auth:
             auth = base64.encodestring(unquote(auth))
@@ -367,10 +369,12 @@ class SafeTransport(Transport):
 
 class ServerProxy:
     def __init__(self, uri, transport=None, encoding=None, verbose=None, allow_none=0):
-        utype, uri = splittype(uri)
+        parsed_url = urlparse(uri)
+        utype = parsed_url.scheme
         if utype not in ('http', 'https'):
             raise OSError('Unsupported JSONRPC protocol')
-        self.__host, self.__handler = splithost(uri)
+        self.__host = parsed_url.hostname
+        self.__handler = parsed_url.path
         if not self.__handler:
             self.__handler = '/RPC2'
 

--- a/tests/web/jsonrpclib.py
+++ b/tests/web/jsonrpclib.py
@@ -32,7 +32,7 @@
 import base64
 import json
 from http.client import HTTPConnection, HTTPSConnection
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 
 __version__ = '0.0.1'
@@ -234,7 +234,7 @@ class Transport:
             host, x509 = host
 
         parsed_url = urlparse(host)
-        auth = f"{parsed_url.username}:{parsed_url.password}"
+        auth = f'{parsed_url.username}:{parsed_url.password}'
         host = parsed_url.hostname
 
         if auth:


### PR DESCRIPTION
```
tests/web/test_jsonrpc.py::test
  /home/runner/work/circuits/circuits/tests/web/jsonrpclib.py:370: DeprecationWarning: urllib.parse.splittype() is deprecated as of 3.8, use urllib.parse.urlparse() instead
    utype, uri = splittype(uri)
tests/web/test_jsonrpc.py::test
  /home/runner/work/circuits/circuits/tests/web/jsonrpclib.py:373: DeprecationWarning: urllib.parse.splithost() is deprecated as of 3.8, use urllib.parse.urlparse() instead
    self.__host, self.__handler = splithost(uri)
tests/web/test_jsonrpc.py::test
  /home/runner/work/circuits/circuits/tests/web/jsonrpclib.py:236: DeprecationWarning: urllib.parse.splituser() is deprecated as of 3.8, use urllib.parse.urlparse() instead
    auth, host = splituser(host)
```

Replaces above uses with urllib.parse.urlparse and passed appropriate elements from the named tuple it returns.

Refs #335
