### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/circuits/node/utils.py
+++ b/circuits/node/utils.py
@@ -9,6 +9,8 @@ META_EXCLUDE.add('node_sock')
 META_EXCLUDE.add('node_without_result')
 META_EXCLUDE.add('success_channels')
 
+META_ALLOWLIST = frozenset()
+
 
 def load_event(s):
     data = json.loads(s)
@@ -34,7 +36,17 @@ def load_event(s):
     e.notify = bool(data['notify'])
     e.channels = tuple(data['channels'])
 
-    for k, v in dict(data['meta']).items():
+    meta = data.get('meta', {})
+    if not isinstance(meta, dict):
+        raise ValueError('Invalid event meta')
+
+    for k, v in meta.items():
+        if not isinstance(k, str):
+            raise ValueError('Invalid event meta key')
+        if k not in META_ALLOWLIST or k.startswith('_') or k in META_EXCLUDE:
+            raise ValueError('Unsafe event meta key: %s' % k)
+        if not isinstance(v, (type(None), bool, int, float, str, list, dict)):
+            raise ValueError('Invalid event meta value: %s' % k)
         setattr(e, k, v)
 
     return e, data['id']
@@ -42,7 +54,7 @@ def load_event(s):
 
 def dump_event(e, id):
     meta = {}
-    for name in list(set(dir(e)) - META_EXCLUDE):
+    for name in list((set(dir(e)) - META_EXCLUDE) & META_ALLOWLIST):
         meta[name] = getattr(e, name)
 
     data = {
@@ -64,7 +76,7 @@ def dump_value(v):
     meta = {}
     e = v.event
     if e:
-        for name in list(set(dir(e)) - META_EXCLUDE):
+        for name in list((set(dir(e)) - META_EXCLUDE) & META_ALLOWLIST):
             meta[name] = getattr(e, name)
 
     data = {

--- a/circuits/web/dispatchers/virtualhosts.py
+++ b/circuits/web/dispatchers/virtualhosts.py
@@ -36,17 +36,30 @@ class VirtualHosts(BaseComponent):
 
     channel = 'web'
 
-    def __init__(self, domains):
+    def __init__(self, domains, trusted_proxies=None):
         super().__init__()
 
         self.domains = domains
+        self.trusted_proxies = set(trusted_proxies or ())
 
     @handler('request', priority=1.0)
     def _on_request(self, event, request, response):
         path = request.path.strip('/')
 
         header = request.headers.get
-        domain = header('X-Forwarded-Host', header('Host', ''))
+        domain = header('Host', '').strip()
+
+        if self.trusted_proxies:
+            remote = getattr(request, 'remote', None)
+            remote_ip = getattr(remote, 'ip', None)
+            if remote_ip is None and isinstance(remote, (list, tuple)) and remote:
+                remote_ip = remote[0]
+
+            if remote_ip in self.trusted_proxies:
+                forwarded = header('X-Forwarded-Host', '')
+                if forwarded:
+                    domain = forwarded.split(',', 1)[0].strip()
+
         prefix = self.domains.get(domain, '')
 
         if prefix:


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `circuits/web/dispatchers/virtualhosts.py:L47`

The virtual host dispatcher uses `X-Forwarded-Host` first, then `Host`, without verifying that the request actually came through a trusted reverse proxy. A direct client can spoof `X-Forwarded-Host` and influence route prefix selection, potentially bypassing virtual host isolation and accessing unintended application paths.

## Solution

Only honor `X-Forwarded-Host` when the immediate peer is a trusted proxy (allowlist of proxy IPs), otherwise use the raw `Host` header. Consider normalizing and strictly validating host values (including optional port) before lookup.

## Changes

- `circuits/web/dispatchers/virtualhosts.py` (modified)
- `circuits/node/utils.py` (modified)